### PR TITLE
Issue/18

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,8 +33,6 @@ Once you have imported the project, require it and provide the initial configura
     const accountId = 'MOCK_ACCOUNT_ID'
     const authToken = 'MOCK_AUTH_TOKEN'
     const persy = PersephonySDK(accountId, authToken)
-    // Because Persephony is hosted multiple places, the SDK must be told which one you are using
-    persy.api.setPersyUrl('https://persephony.com/apiserver')
 
 Module
 ======

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@persephony/sdk",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "The SDK for the Persephony API",
   "homepage":"https://www.persephony.com",
   "bugs":{

--- a/src/api/requester/requester.js
+++ b/src/api/requester/requester.js
@@ -5,8 +5,7 @@ var querystring = require('querystring')
 /**
  * The URL of the Persephony API
  */
-// TODO - change this to https://www.persephony.com/apiserver
-var persyURL = 'https://localhost/apiserver'
+var persyURL = 'https://www.persephony.com/apiserver'
 // TODO - delete this, very insecure
 var agent = new https.Agent({
   rejectUnauthorized: false


### PR DESCRIPTION
This should change the default base URL to the public persephony.com deployment instead of forcing all users of the package to manually override it on first setting. Note that the capability to override it is still exposed to allow targeting other instances of the platform.

Because this breaks existing behavior, this is a major version change.