### PR TITLE
Documentation fixes

### DIFF
--- a/docs/source/api/accounts.rst
+++ b/docs/source/api/accounts.rst
@@ -8,7 +8,7 @@ get(accountId)
 
     :accountId: {string} The :code:`accountId` of the desired account.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the account matching the :code:`accountId` provided.
+    :returns: {Promise<object>} A promise that resolves to the account matching the :code:`accountId` provided.
     :throws: Will throw an error on a failed response.
 
 
@@ -20,5 +20,5 @@ update(accountId, options)
     :accountId: {string} The :code:`accountId` of the desired account.
     :options: {object} The properties to change in the target account.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the account matching the :code:`accountId` provided.
+    :returns: {Promise<object>} A promise that resolves to the account matching the :code:`accountId` provided.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/api.rst
+++ b/docs/source/api/api.rst
@@ -18,6 +18,6 @@ API
 setPersyUrl(newUrl)
 ^^^^^^^^^^^^^^^^^^^^^
 
-    Change the Persephony instance the SDK interacts with.
+    Change the Persephony instance the SDK interacts with. Persy Url defaults to https://persephony.com/apiserver
 
     :newUrl: {string} The URL to the api of the Persephony instance to use. e.g https://persephony.com/apiserver

--- a/docs/source/api/api.rst
+++ b/docs/source/api/api.rst
@@ -18,6 +18,6 @@ API
 setPersyUrl(newUrl)
 ^^^^^^^^^^^^^^^^^^^^^
 
-    Change the Persephony instance the SDK interacts with. Persy Url defaults to https://persephony.com/apiserver
+    Change the Persephony instance the SDK interacts with. https://persephony.com/apiserver by default
 
     :newUrl: {string} The URL to the api of the Persephony instance to use. e.g https://persephony.com/apiserver

--- a/docs/source/api/applications.rst
+++ b/docs/source/api/applications.rst
@@ -16,8 +16,8 @@ update(applicationId, options)
 
     Update the existing application associated with :code:`applicationId`.
 
-    :applicationId: {stirng} The :code:`applicationId` of the desired application.
-    :options: {object} The properites to change in the target application.
+    :applicationId: {string} The :code:`applicationId` of the desired application.
+    :options: {object} The properties to change in the target application.
 
     :returns: {Promise<object>} A promise that resolves to the application matching the :code:`applicationId` provided.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/applications.rst
+++ b/docs/source/api/applications.rst
@@ -8,7 +8,7 @@ get(applicationId)
 
     :applicationId: {string} The :code:`applicationId` of the desired application.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the application matching the :code:`applicationId` provided.
+    :returns: {Promise<object>} A promise that resolves to the application matching the :code:`applicationId` provided.
     :throws: Will throw an error on a failed response.
 
 update(applicationId, options)
@@ -19,7 +19,7 @@ update(applicationId, options)
     :applicationId: {stirng} The :code:`applicationId` of the desired application.
     :options: {object} The properites to change in the target application.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the application matching the :code:`applicationId` provided.
+    :returns: {Promise<object>} A promise that resolves to the application matching the :code:`applicationId` provided.
     :throws: Will throw an error on a failed response.
 
 getList(filters)
@@ -29,7 +29,7 @@ getList(filters)
 
     :[filters]: {object} An object containing a number of possible ways to filter the applications.
 
-    :returns: {Promise<object>} Returns a promise that resolves to an application list.
+    :returns: {Promise<object>} A promise that resolves to an application list.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -49,7 +49,7 @@ create(options)
 
     :options: {object} Arguments that can be provided when creating an application. See Persephony documentation for details.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the newly created application.
+    :returns: {Promise<object>} A promise that resolves to the newly created application.
     :throws: Will throw an error on a failed response.
 
 delete(applicationId)
@@ -59,5 +59,5 @@ delete(applicationId)
 
     :applicationId: {string} The :code:`applicationId` of the application to delete.
 
-    :returns: {Promise<null>} Returns a promise that resolves to null on success.
+    :returns: {Promise<null>} A promise that resolves to null on success.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/availableNumbers.rst
+++ b/docs/source/api/availableNumbers.rst
@@ -8,7 +8,7 @@ getList(filters)
 
     :[filters]: {object} Optional properties to filter the list.
 
-    :returns: {Promise<object>} Returns a promise that resolves to a page of phone numbers.
+    :returns: {Promise<object>} A promise that resolves to a page of phone numbers.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)

--- a/docs/source/api/availableNumbers.rst
+++ b/docs/source/api/availableNumbers.rst
@@ -4,7 +4,7 @@ Available Numbers
 getList(filters)
 ^^^^^^^^^^^^^^^^^^
 
-    Retrieve the list of available phone numbers for purchase.`
+    Retrieve a list of available phone numbers for purchase.
 
     :[filters]: {object} Optional properties to filter the list.
 

--- a/docs/source/api/availableNumbers.rst
+++ b/docs/source/api/availableNumbers.rst
@@ -6,7 +6,7 @@ getList(filters)
 
     Retrieve a list of available phone numbers for purchase.
 
-    :[filters]: {object} Optional properties to filter the list.
+    :[filters]: {object} Properties to filter the list.
 
     :returns: {Promise<object>} A promise that resolves to a page of phone numbers.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/callingNumbers.rst
+++ b/docs/source/api/callingNumbers.rst
@@ -8,7 +8,7 @@ get(callingNumberId)
 
     :callingNumberId: {string} The :code:`callingNumberId` of the desired calling number.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the calling number matching the :code:`callingNumberId` provided.
+    :returns: {Promise<object>} A promise that resolves to the calling number matching the :code:`callingNumberId` provided.
     :throws: Will throw an error on a failed response.
 
 update(callingNumberId, options)
@@ -19,7 +19,7 @@ update(callingNumberId, options)
     :callingNumberId: {string} The :code:`callingNumberId` of the desired calling number.
     :options: {object} The properties to change in the target calling number.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the calling number matching the :code:`callingNumberId` provided.
+    :returns: {Promise<object>} A promise that resolves to the calling number matching the :code:`callingNumberId` provided.
     :throws: Will throw an error on a failed response.
 
 getList(options)
@@ -29,7 +29,7 @@ getList(options)
 
     :[options]: {object} Optional properties to filter the list.
 
-    :returns: {Promise<object>} Returns a promise that resolves to a page of calling numbers.
+    :returns: {Promise<object>} A promise that resolves to a page of calling numbers.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -50,7 +50,7 @@ create(phoneNumber, options)
     :phoneNumber: {string} The phone number to add. Should be formatted with a '+' and country code e.g. +16175551212 (E.164 format). Persephony will also accept unformatted US number e.g. (415) 555-1212, 415-555-1212.
     :[options]: {object} The optional properties to set on the new calling number.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the newly created calling number.
+    :returns: {Promise<object>} A promise that resolves to the newly created calling number.
     :throws: Will throw an error on a failed response.
 
 delete(callingNumberId)
@@ -60,5 +60,5 @@ delete(callingNumberId)
 
     :callingNumberId: {string} The id of the calling number to delete.
 
-    :returns: {Promise<null>} Returns a promise that resolves to null on success.
+    :returns: {Promise<null>} A promise that resolves to null on success.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/callingNumbers.rst
+++ b/docs/source/api/callingNumbers.rst
@@ -25,7 +25,7 @@ update(callingNumberId, options)
 getList(options)
 ^^^^^^^^^^^^^^^^^^
 
-    Retrieve the list of calling numbers associated with the :code:`accountId`.
+    Retrieve a list of calling numbers associated with the :code:`accountId`.
 
     :[options]: {object} Optional properties to filter the list.
 

--- a/docs/source/api/callingNumbers.rst
+++ b/docs/source/api/callingNumbers.rst
@@ -27,7 +27,7 @@ getList(options)
 
     Retrieve a list of calling numbers associated with the :code:`accountId`.
 
-    :[options]: {object} Optional properties to filter the list.
+    :[options]: {object} Properties to filter the list.
 
     :returns: {Promise<object>} A promise that resolves to a page of calling numbers.
     :throws: Will throw an error on a failed response.
@@ -48,7 +48,7 @@ create(phoneNumber, options)
     Create a new calling number through the Persephony API.
 
     :phoneNumber: {string} The phone number to add. Should be formatted with a '+' and country code e.g. +16175551212 (E.164 format). Persephony will also accept unformatted US number e.g. (415) 555-1212, 415-555-1212.
-    :[options]: {object} The optional properties to set on the new calling number.
+    :[options]: {object} Properties to set on the new calling number.
 
     :returns: {Promise<object>} A promise that resolves to the newly created calling number.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/calls.rst
+++ b/docs/source/api/calls.rst
@@ -47,8 +47,8 @@ create(to, from, applicationId, options)
 
     Create a new call through the Persephony API.
 
-    :to: {string} The number to call out to (DNIS). This can be any valid phone number formatted in E.164 format in Persephony's service area. Must be associated with application specified with :code:`applicationId`
-    :from: {string} The number to call from (ANI). This must be a number purchased from Persephony or a verified phone number owned by the user.
+    :to: {string} The number to call out to (DNIS). This can be any valid phone number formatted in E.164 format in Persephony's service area.
+    :from: {string} The number to call from (ANI). This must be a number purchased from Persephony or a verified phone number owned by the user. Must be associated with application specified with :code:`applicationId`
     :applicationId: {string} The id of the application Persephony should use to handle the phone call.
     :[options]: {object} Additional properties to set the behavior of the call to be placed.
 

--- a/docs/source/api/calls.rst
+++ b/docs/source/api/calls.rst
@@ -47,7 +47,7 @@ create(to, from, applicationId, options)
 
     Create a new call through the Persephony API.
 
-    :to: {string} The number to call out to (DNIS). This can be any valid phone number formatted in E.164 format in Persephony's service area.
+    :to: {string} The number to call out to (DNIS). This can be any valid phone number formatted in E.164 format in Persephony's service area. Must be associated with application specified with :code:`applicationId`
     :from: {string} The number to call from (ANI). This must be a number purchased from Persephony or a verified phone number owned by the user.
     :applicationId: {string} The id of the application Persephony should use to handle the phone call.
     :[options]: {object} Additional properties to set the behavior of the call to be placed.

--- a/docs/source/api/calls.rst
+++ b/docs/source/api/calls.rst
@@ -8,7 +8,7 @@ get(callId)
 
     :callId: {string} The :code:`callId` of the desired call.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the call matching the :code:`callId` provided.
+    :returns: {Promise<object>} A promise that resolves to the call matching the :code:`callId` provided.
     :throws: Will throw an error on a failed response.
 
 update(callId, status)
@@ -19,7 +19,7 @@ update(callId, status)
     :callId: {string} The :code:`callId` of the desired call.
     :status: {string} The status to set the target call to. Can be either :ref:`Enums-callStatus-label`.CANCELED or :ref:`Enums-callStatus-label`.COMPLETED.
 
-    :returns: {Promise<null>} Returns a promise that resolves to null on success
+    :returns: {Promise<null>} A promise that resolves to null on success
     :throws: Will throw an error on a failed response.
 
 getList(filters)
@@ -29,7 +29,7 @@ getList(filters)
 
     :[filters]: {object} Optional filters containing a number of possible ways to filter the calls returned by Persephony.
 
-    :returns: {Promise<object>} Returns a promise that resolves to a list of call instances matching the filters if provided.
+    :returns: {Promise<object>} A promise that resolves to a list of call instances matching the filters if provided.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -39,7 +39,7 @@ getNextPage(nextPageUri)
 
     :nextPageUri: {string} The URL to the next page of results.
 
-    :returns: {Promise<oobject>} Returns a promise that resolves to the next page of calls
+    :returns: {Promise<oobject>} A promise that resolves to the next page of calls
     :throws: Will throw an error on a filed response.
 
 create(to, from, applicationId, options)
@@ -52,5 +52,5 @@ create(to, from, applicationId, options)
     :applicationId: {string} The id of the application Persephony should use to handle the phone call.
     :[options]: {object} Additional properties to set the behavior of the call to be placed.
 
-    :returns: {Promise<object>} returns a promise that resolves to the newly placed call.
+    :returns: {Promise<object>} A promise that resolves to the newly placed call.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/calls.rst
+++ b/docs/source/api/calls.rst
@@ -39,7 +39,7 @@ getNextPage(nextPageUri)
 
     :nextPageUri: {string} The URL to the next page of results.
 
-    :returns: {Promise<oobject>} A promise that resolves to the next page of calls
+    :returns: {Promise<object>} A promise that resolves to the next page of calls
     :throws: Will throw an error on a filed response.
 
 create(to, from, applicationId, options)

--- a/docs/source/api/calls.rst
+++ b/docs/source/api/calls.rst
@@ -40,7 +40,7 @@ getNextPage(nextPageUri)
     :nextPageUri: {string} The URL to the next page of results.
 
     :returns: {Promise<object>} A promise that resolves to the next page of calls
-    :throws: Will throw an error on a filed response.
+    :throws: Will throw an error on a failed response.
 
 create(to, from, applicationId, options)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/api/calls.rst
+++ b/docs/source/api/calls.rst
@@ -27,7 +27,7 @@ getList(filters)
 
     Retrieve a list of calls associated with the :code:`accountId`
 
-    :[filters]: {object} Optional filters containing a number of possible ways to filter the calls returned by Persephony.
+    :[filters]: {object} Filters containing a number of possible ways to filter the calls returned by Persephony.
 
     :returns: {Promise<object>} A promise that resolves to a list of call instances matching the filters if provided.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/conferences/conferences.rst
+++ b/docs/source/api/conferences/conferences.rst
@@ -22,7 +22,7 @@ update(conferenceId, options)
     Update the existing conference associated with the :code:`conferenceId`
 
     :conferenceId: {string} The :code:`conferenceId` of the desired conference.
-    :options: {object} THe properties to change in the target conference.
+    :options: {object} The properties to change in the target conference.
 
     :returns: {Promise<object>} A promise that will resolve to the conference matching the :code:`conferenceId` provided.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/conferences/conferences.rst
+++ b/docs/source/api/conferences/conferences.rst
@@ -32,7 +32,7 @@ getList(filters)
 
     Retrieve a list of conference associated with the :code:`accountId`
 
-    :[filters]: {object} Optional properties to filter the list
+    :[filters]: {object} Properties to filter the list
 
     :returns: {Promise<object>} A promise that resolves to a conference list.
     :throws: Will throw an error on a failed response.
@@ -52,7 +52,7 @@ create(options)
 
     Create a new conference through the Persephony API.
 
-    :[options]: {object} Optional properties to set when creating a conference.
+    :[options]: {object} Properties to set when creating a conference.
 
     :returns: {Promise<object>} A promise that resolves to the newly created conference.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/conferences/conferences.rst
+++ b/docs/source/api/conferences/conferences.rst
@@ -13,7 +13,7 @@ get(conferenceId)
 
     :conferenceId: {string} The :code:`conferenceId` of the desired conference.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the conference matching the :code:`conferenceId` provided.
+    :returns: {Promise<object>} A promise that resolves to the conference matching the :code:`conferenceId` provided.
     :throws: Will throw an error on a failed response.
 
 update(conferenceId, options)
@@ -24,7 +24,7 @@ update(conferenceId, options)
     :conferenceId: {string} The :code:`conferenceId` of the desired conference.
     :options: {object} THe properties to change in the target conference.
 
-    :returns: {Promise<object>} Returns a promise that will resolve to the conference matching the :code:`conferenceId` provided.
+    :returns: {Promise<object>} A promise that will resolve to the conference matching the :code:`conferenceId` provided.
     :throws: Will throw an error on a failed response.
 
 getList(filters)
@@ -34,7 +34,7 @@ getList(filters)
 
     :[filters]: {object} Optional properties to filter the list
 
-    :returns: {Promise<object>} Returns a promise that resolves to a conference list.
+    :returns: {Promise<object>} A promise that resolves to a conference list.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -44,7 +44,7 @@ getNextPage(nextPageUri)
 
     :nextPageUri: {string} The URL to the next page of results.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the next page of conferences.
+    :returns: {Promise<object>} A promise that resolves to the next page of conferences.
     :throws: Will throw an error on a failed response.
 
 create(options)
@@ -54,7 +54,7 @@ create(options)
 
     :[options]: {object} Optional properties to set when creating a conference.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the newly created conference.
+    :returns: {Promise<object>} A promise that resolves to the newly created conference.
     :throws: Will throw an error on a failed response.
 
 .. _API-conferences-participants-label:

--- a/docs/source/api/conferences/participants.rst
+++ b/docs/source/api/conferences/participants.rst
@@ -12,7 +12,7 @@ get(participantId)
 
     :participantId: {string} The :code:`callId` of the desired participant.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the participant matching the :code:`callId` provided.
+    :returns: {Promise<object>} A promise that resolves to the participant matching the :code:`callId` provided.
     :throws: Will throw an error on a failed response.
 
 update(participantId, options)
@@ -23,7 +23,7 @@ update(participantId, options)
     :participantId: {string} The :code:`callId` of the desired participant.
     :options: {object} The properites to change on the target participant.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the participant matching the :code:`callId` provided.
+    :returns: {Promise<object>} A promise that resolves to the participant matching the :code:`callId` provided.
     :throws: Will throw an error on a failed response.
 
 getList(filters)
@@ -33,7 +33,7 @@ getList(filters)
 
     :[filters]: {object} An object containing a number of possible ways to filter the participants returned by Persephony.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the list of participants for the conference.
+    :returns: {Promise<object>} A promise that resolves to the list of participants for the conference.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -43,7 +43,7 @@ getNextPage(nextPageUri)
 
     :nextPageUri: {string} The URL to the next page of results.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the next page of participants.
+    :returns: {Promise<object>} A promise that resolves to the next page of participants.
     :throws: Will throw an error on a failed response.
 
 delete(participantId)
@@ -53,5 +53,5 @@ delete(participantId)
 
     :participantId: {string} The :code:`callId` of the desired participant.
 
-    :returns: {Promise<null>} Returns a promise that resolves to null on success.
+    :returns: {Promise<null>} A promise that resolves to null on success.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/incomingNumbers.rst
+++ b/docs/source/api/incomingNumbers.rst
@@ -27,7 +27,7 @@ getList(filter)
 
     Retrieve a list of incoming phone numbers associated with the :code:`accountId`.
 
-    :[filter]: {object} Optional properties to filter the list.
+    :[filter]: {object} Properties to filter the list.
 
     :returns: {Promise<object>} A promise that resolves to a page of incoming phone numbers.
     :throws: Will throw an error on a failed response.
@@ -48,7 +48,7 @@ purchase(phoneNumber, options)
     Purchase a new incoming phone number through the Persephony API.
 
     :phoneNumber: {string} The phone number to purchase in E.164 format (as returned in the list of Available Phone Numbers)
-    :[options]: {object} Optional properties to set on the newly purchased number.
+    :[options]: {object} Properties to set on the newly purchased number.
 
     :returns: {Promise<object>} A promise that resolves to the newly purchased incoming phone number.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/incomingNumbers.rst
+++ b/docs/source/api/incomingNumbers.rst
@@ -6,7 +6,7 @@ get(incomingNumberId)
 
     Retrieve a single incoming phone number from Persephony.
 
-    :incomingNumberId: {string} The :code:`incomingPhoneNumberId` of the desirect incoming phone number.
+    :incomingNumberId: {string} The :code:`incomingPhoneNumberId` of the desired incoming phone number.
 
     :returns: {Promise<object>} A promise that resolves to the desired number.
     :throws: Will throw an error on a failed response.
@@ -25,7 +25,7 @@ update(incomingNumberId, options)
 getList(filter)
 ^^^^^^^^^^^^^^^^^^
 
-    Retrieve the list of incoming phone numbers associated with the :code:`accountId`.
+    Retrieve a list of incoming phone numbers associated with the :code:`accountId`.
 
     :[filter]: {object} Optional properties to filter the list.
 
@@ -56,7 +56,7 @@ purchase(phoneNumber, options)
 delete(incomingNumberId)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    Remove the incoming phone number with a matching :code:`incomingPhoneNumberId` as an incoming number. Persephony will no longer answer calls to this number.
+    Remove the incoming phone number with a matching :code:`incomingPhoneNumberId`. Persephony will no longer answer calls to this number.
 
     :incomingNumberId: {string} The id of the incoming phone number to delete.
 

--- a/docs/source/api/incomingNumbers.rst
+++ b/docs/source/api/incomingNumbers.rst
@@ -8,7 +8,7 @@ get(incomingNumberId)
 
     :incomingNumberId: {string} The :code:`incomingPhoneNumberId` of the desirect incoming phone number.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the desired number.
+    :returns: {Promise<object>} A promise that resolves to the desired number.
     :throws: Will throw an error on a failed response.
 
 update(incomingNumberId, options)
@@ -19,7 +19,7 @@ update(incomingNumberId, options)
     :incomingNumberId: {string} The :code:`incomingPhoneNumberId` of the desired incoming phone number.
     :options: {object} The properties to change in the target incoming phone number.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the modified incoming phone number.
+    :returns: {Promise<object>} A promise that resolves to the modified incoming phone number.
     :throws: Will throw an error on a failed response.
 
 getList(filter)
@@ -29,7 +29,7 @@ getList(filter)
 
     :[filter]: {object} Optional properties to filter the list.
 
-    :returns: {Promise<object>} Returns a promise that resolves to a page of incoming phone numbers.
+    :returns: {Promise<object>} A promise that resolves to a page of incoming phone numbers.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -50,7 +50,7 @@ purchase(phoneNumber, options)
     :phoneNumber: {string} The phone number to purchase in E.164 format (as returned in the list of Available Phone Numbers)
     :[options]: {object} Optional properties to set on the newly purchased number.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the newly purchased incoming phone number.
+    :returns: {Promise<object>} A promise that resolves to the newly purchased incoming phone number.
     :throws: Will throw an error on a failed response.
 
 delete(incomingNumberId)
@@ -60,5 +60,5 @@ delete(incomingNumberId)
 
     :incomingNumberId: {string} The id of the incoming phone number to delete.
 
-    :returns: {Promise<null>} Returns a promise that resolves to null on success.
+    :returns: {Promise<null>} A promise that resolves to null on success.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/logs.rst
+++ b/docs/source/api/logs.rst
@@ -8,7 +8,7 @@ get(filters)
 
     :[filters]: {object} An object containing a number of ways to filter the logs returned by Perspehony.
 
-    :returns: {Promise<object>} Returns a promise that resolves to a page of logs.
+    :returns: {Promise<object>} A promise that resolves to a page of logs.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)

--- a/docs/source/api/messages.rst
+++ b/docs/source/api/messages.rst
@@ -9,7 +9,7 @@ get(messageId)
 
     :messageId: {string} The :code:`messageId` of the desired message.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the message matching the :code:`messageId` provided.
+    :returns: {Promise<object>} A promise that resolves to the message matching the :code:`messageId` provided.
     :throws: Will throw an error on a failed response.
 
 getList(filters)
@@ -19,7 +19,7 @@ getList(filters)
 
     :[filters]: {object} Optional properties to filter the list.
 
-    :returns: {Promise<object>} Returns a promise that resolves to a page of messages.
+    :returns: {Promise<object>} A promise that resolves to a page of messages.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -41,5 +41,5 @@ create(from, to, text)
     :to: {string} The phone number to send the message to.
     :text: {string} The text contained in the message. (maximum 254 characters.)
 
-    :returns: {Promise<object>} Returns a promise that resolves to the newly created message.
+    :returns: {Promise<object>} A promise that resolves to the newly created message.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/messages.rst
+++ b/docs/source/api/messages.rst
@@ -37,7 +37,7 @@ create(from, to, text)
 
     Send an SMS message through the Persephony API.
 
-    :from: {string} The phone number to use as the sender. This must be an incoming phone number you have purchased from Persephony.
+    :from: {string} The phone number to use as the sender. This must be an incoming phone number you have purchased from Persephony (E.164 format).
     :to: {string} The phone number to send the message to.
     :text: {string} The text contained in the message. (maximum 254 characters.)
 

--- a/docs/source/api/messages.rst
+++ b/docs/source/api/messages.rst
@@ -17,7 +17,7 @@ getList(filters)
 
     Retrieve a list of messages associated with the :code:`accountId`
 
-    :[filters]: {object} Optional properties to filter the list.
+    :[filters]: {object} Properties to filter the list.
 
     :returns: {Promise<object>} A promise that resolves to a page of messages.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/queues/members.rst
+++ b/docs/source/api/queues/members.rst
@@ -12,7 +12,7 @@ get(memberId)
 
     :memberId: {string} The :code:`callId` of the desired member.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the member matching the :code:`callId` provided.
+    :returns: {Promise<object>} A promise that resolves to the member matching the :code:`callId` provided.
     :throws: Will throw an error on a failed response.
 
 getFront()
@@ -20,7 +20,7 @@ getFront()
 
     Retrieve a single member from the front of the queue.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the member at the front of the queue.
+    :returns: {Promise<object>} A promise that resolves to the member at the front of the queue.
     :throws: Will throw an error on a failed response.
 
 getList()
@@ -28,7 +28,7 @@ getList()
 
     Retrieve a list of members associated with the queue.
 
-    :returns: {Promise<object>} Returns a promise that resolves to a list of members.
+    :returns: {Promise<object>} A promise that resolves to a list of members.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -38,7 +38,7 @@ getNextPage(nextPageUri)
 
     :nextPageUri: {string} The URL to the next page of results.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the next page of results.
+    :returns: {Promise<object>} A promise that resolves to the next page of results.
     :throws: Will throw an error on a failed response.
 
 dequeue(memberId)
@@ -48,7 +48,7 @@ dequeue(memberId)
 
     :memberId: {string} The :code:`callId` of the desired member.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the member matching the :code:`callId` provided.
+    :returns: {Promise<object>} A promise that resolves to the member matching the :code:`callId` provided.
     :throws: Will throw an error on a failed response.
 
 dequeueFront()
@@ -56,5 +56,5 @@ dequeueFront()
 
     Dequeue a single member from the front of the queue.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the member at the front of the queue.
+    :returns: {Promise<object>} A promise that resolves to the member at the front of the queue.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/queues/queues.rst
+++ b/docs/source/api/queues/queues.rst
@@ -32,7 +32,7 @@ getList(filters)
 
     Retrieve a list of queues associated with the :code:`accountId`.
 
-    :[filters]: {object} An optional object containing a number of possible ways to filter the queues returned by Persephony.
+    :[filters]: {object} Object containing a number of possible ways to filter the queues returned by Persephony.
 
     :returns: {Promise<object>} A promise that resolves to a queue list page.
     :throws: Will throw an error on a failed response.
@@ -52,7 +52,7 @@ create(options)
 
     Create a new queue through the Persephony API.
 
-    :[options]: {object} An optional object to set the properties on the newly created queue.
+    :[options]: {object} An Object to set the properties on the newly created queue.
 
     :returns: {Promise<object>} A promise that resolves to the newly created queue.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/queues/queues.rst
+++ b/docs/source/api/queues/queues.rst
@@ -13,7 +13,7 @@ get(queueId)
 
     :queueId: {string} The :code:`queueId` of the desired queue.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the queue matching the provided id.
+    :returns: {Promise<object>} A promise that resolves to the queue matching the provided id.
     :throws: Will throw an error on a failed response.
 
 update(queueId, options)
@@ -24,7 +24,7 @@ update(queueId, options)
     :queueId: {string} The :code:`queueId` of the desired queue.
     :options: {object} The properties to change in the target queue.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the queue matching the :code:`queueId` provided.
+    :returns: {Promise<object>} A promise that resolves to the queue matching the :code:`queueId` provided.
     :throws: Will throw an error on a failed response.
 
 getList(filters)
@@ -34,7 +34,7 @@ getList(filters)
 
     :[filters]: {object} An optional object containing a number of possible ways to filter the queues returned by Persephony.
 
-    :returns: {Promise<object>} Returns a promise that resolves to a queue list page.
+    :returns: {Promise<object>} A promise that resolves to a queue list page.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -44,7 +44,7 @@ getNextPage(nextPageUri)
 
     :nextPageUri: {string} The URL to the next page of results.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the next page of queues.
+    :returns: {Promise<object>} A promise that resolves to the next page of queues.
     :throws: Will throw an error on a failed response.
 
 create(options)
@@ -54,7 +54,7 @@ create(options)
 
     :[options]: {object} An optional object to set the properties on the newly created queue.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the newly created queue.
+    :returns: {Promise<object>} A promise that resolves to the newly created queue.
     :throws: Will throw an error on a failed response.
 
 .. _API-queues-members-label:

--- a/docs/source/api/recordings.rst
+++ b/docs/source/api/recordings.rst
@@ -39,7 +39,7 @@ download(recordingId, filePath)
     :recordingId: {string} The :code:`recordingId` of the desired recording.
     :filePath: {string} The path to the location on disk and filename to save the recording to.
 
-    :returns {Promise<undefined>} A promise that resolves to undefined once the request succeeds.
+    :returns: {Promise<undefined>} A promise that resolves to undefined once the request succeeds.
     :throws: Will throw an error on a failed response.
 
 stream(recordingId)

--- a/docs/source/api/recordings.rst
+++ b/docs/source/api/recordings.rst
@@ -16,7 +16,7 @@ getList(filters)
 
     Retrieve a list of recording metadata associated with the :code:`accountId`.
 
-    :[filters]: {object} Optional properties to filter the recording list Persephony will return.
+    :[filters]: {object} Properties to filter the recording list Persephony will return.
 
     :returns: {Promise<object>} A promise that resolves into a page of metadata about the available recordings.
     :throws: Will throw an error on a failed response.

--- a/docs/source/api/recordings.rst
+++ b/docs/source/api/recordings.rst
@@ -8,7 +8,7 @@ get(recordingId)
 
     :recordingId: {string} The :code:`recordingId` of the desired recording.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the recording metadata about the recording matching the :code:`recordingId` provided.
+    :returns: {Promise<object>} A promise that resolves to the recording metadata about the recording matching the :code:`recordingId` provided.
     :throws: Will throw an error on a failed response.
 
 getList(filters)
@@ -18,7 +18,7 @@ getList(filters)
 
     :[filters]: {object} Optional properties to filter the recording list Persephony will return.
 
-    :returns: {Promise<object>} Returns a promise that resolves into a page of metadata about the available recordings.
+    :returns: {Promise<object>} A promise that resolves into a page of metadata about the available recordings.
     :throws: Will throw an error on a failed response.
 
 getNextPage(nextPageUri)
@@ -28,7 +28,7 @@ getNextPage(nextPageUri)
 
     :nextPageUri: {string} The URL to the next page of results.
 
-    :returns: {Promise<object>} Returns a promise that resolves to the next page of recording metadata.
+    :returns: {Promise<object>} A promise that resolves to the next page of recording metadata.
     :throws: Will throw an error on a failed response.
 
 download(recordingId, filePath)
@@ -39,7 +39,7 @@ download(recordingId, filePath)
     :recordingId: {string} The :code:`recordingId` of the desired recording.
     :filePath: {string} The path to the location on disk and filename to save the recording to.
 
-    :returns {Promise<undefined>} Returns a promise that resolves to undefined once the request succeeds.
+    :returns {Promise<undefined>} A promise that resolves to undefined once the request succeeds.
     :throws: Will throw an error on a failed response.
 
 stream(recordingId)
@@ -49,7 +49,7 @@ stream(recordingId)
 
     :recordingId: {string} The :code:`recordingId` of the desired recording.
 
-    :returns: {Promise<Stream>} Returns a promise that resolves to a ReadableStream - A Node.js Readable Stream for independent decoding. See `here <https://nodejs.org/api/stream.html#stream_readable_streams>`_.
+    :returns: {Promise<Stream>} A promise that resolves to a ReadableStream - A Node.js Readable Stream for independent decoding. See `here <https://nodejs.org/api/stream.html#stream_readable_streams>`_.
     :throws: Will throw an error on a failed response.
 
 delete(recordingId)
@@ -59,5 +59,5 @@ delete(recordingId)
 
     :recordingId: {string} The :code:`recordingId` of the recording to delete.
 
-    :returns: {Promise<null>} Returns a promise that resolves to null on success.
+    :returns: {Promise<null>} A promise that resolves to null on success.
     :throws: Will throw an error on a failed response.

--- a/docs/source/enums/enums.rst
+++ b/docs/source/enums/enums.rst
@@ -148,8 +148,8 @@ Enum for the allowed values for the language property of the Say command.
 - ENGLISH_UK
 - ENGLISH_IN
 - ENGLISH_US
-- ENGLISH-ES
-- ENGLISH-MX
+- ENGLIS_ES
+- ENGLISH_MX
 - FINNISH
 - FRENCH_CA
 - FRENCH_FE

--- a/docs/source/percl/percl.rst
+++ b/docs/source/percl/percl.rst
@@ -60,7 +60,7 @@ createConference(actionUrl, options)
 
     Build a CreateConference PerCL command.
 
-    :actionUrl: {string} The URl to request once the conference is created.
+    :actionUrl: {string} The URL to request once the conference is created.
     :[options]: {object} Additional properties to include in the command.
 
     :returns: {{CreateConference}} An object representing a CreateConference command.
@@ -194,7 +194,7 @@ getSpeech(actionUrl, grammarFile, options)
 
     Build a GetSpeech PerCL command.
 
-    :actionUrl: {string} The URl to be invoked when the caller has finished speaking or on a timeout.
+    :actionUrl: {string} The URL to be invoked when the caller has finished speaking or on a timeout.
     :grammarFile: {string} The grammar file to be used for speech recognition. If grammarType is set to :ref:`Enums-grammarType-label`.URL this attribute is specified as a dowload URL. Otherwise it must be one of the built-ins. See :ref:`Enums-grammarFileBuiltIn-label`
     :[options]: {object} Additional properties to include in the command.
 

--- a/src/api/calls/calls.js
+++ b/src/api/calls/calls.js
@@ -17,7 +17,7 @@ var common = require('../common/index')
  *
  * @param {string} accountId - The accountId for authentication.
  * @param {string} authToken - The authToken for authentication.
- * @returns {CallsRequester} requester - returns a CallsRequester
+ * @returns {CallsRequester} requester - A CallsRequester
  */
 function calls (accountId, authToken) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/calls/calls.js
+++ b/src/api/calls/calls.js
@@ -61,7 +61,7 @@ function calls (accountId, authToken) {
   /**
    * Retrieve a list of calls associated with the {@code accountId}
    *
-   * @param {object} [filters] - Optional filters containing a number of possible ways to filter the calls returned by Persephony.
+   * @param {object} [filters] - Filters containing a number of possible ways to filter the calls returned by Persephony.
    * @returns {Promise<object>} call list - A list of call instances matching the filters if provided.
    * @throws an error on a failed response
    */

--- a/src/api/conferences/conferences.js
+++ b/src/api/conferences/conferences.js
@@ -21,7 +21,7 @@ var common = require('../common/index')
  *
  * @param {string} accountId - The accountId for authentication.
  * @param {string} authToken - The authToken for authentication.
- * @returns {ConferencesRequester} requester - returns a ConferencesRequester
+ * @returns {ConferencesRequester} requester - A ConferencesRequester
  */
 function conferences (accountId, authToken) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/conferences/conferences.js
+++ b/src/api/conferences/conferences.js
@@ -59,7 +59,7 @@ function conferences (accountId, authToken) {
   /**
    * Retrieve a list of conferences associated with the {@code accountId}.
    *
-   * @param {object} [filters] - Optional properties to filter the list
+   * @param {object} [filters] - Properties to filter the list
    * @returns {Promise<object>} conference list - The list of conferences
    * @throws will throw an error on a failed response
    */
@@ -82,7 +82,7 @@ function conferences (accountId, authToken) {
   /**
    * Create a new conference through the Persephony API.
    *
-   * @param {object} [options] - optional properties to set when creating a conference.
+   * @param {object} [options] - Properties to set when creating a conference.
    * @returns {Promise<object>} conference - The newly created conference
    * @throws will throw an error on a failed response
    */

--- a/src/api/conferences/participants/participants.js
+++ b/src/api/conferences/participants/participants.js
@@ -20,7 +20,7 @@ var common = require('../../common/index')
  * @param {string} accountId - The accountId for authentication.
  * @param {string} authToken - The authToken for authentication.
  * @param {string} conferenceId - The conferenceId to operate against.
- * @returns {ParticipantsRequester} requester - returns a ParticipantsRequester
+ * @returns {ParticipantsRequester} requester - A ParticipantsRequester
  */
 function participants (accountId, authToken, conferenceId) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/logs/logs.js
+++ b/src/api/logs/logs.js
@@ -17,7 +17,7 @@ var common = require('../common/index')
  *
  * @param {string} accountId - The accountId for authentication.
  * @param {string} authToken - The authToken for authentication.
- * @returns {LogsRequester} requester - returns a LogRequester
+ * @returns {LogsRequester} requester - A LogRequester
  */
 function logs (accountId, authToken) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/messages/messages.js
+++ b/src/api/messages/messages.js
@@ -16,7 +16,7 @@ var common = require('../common/index')
  *
  * @param {string} accountId - The accountId for authentication.
  * @param {string} authToken - The authToken for authentication.
- * @returns {MessagesRequester} requester - returns a MessagesRequester
+ * @returns {MessagesRequester} requester - A MessagesRequester
  */
 function messages (accountId, authToken) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/messages/messages.js
+++ b/src/api/messages/messages.js
@@ -41,7 +41,7 @@ function messages (accountId, authToken) {
   /**
    * Retrieve a list of messages associated with the {@code accountId}.
    *
-   * @param {object} [filters] - Optional properties to filter the list
+   * @param {object} [filters] - Properties to filter the list
    * @returns {Promise<object>} message list - The list of messages
    * @throws will throw an error on a failed response
    */

--- a/src/api/phoneNumbers/availableNumbers.js
+++ b/src/api/phoneNumbers/availableNumbers.js
@@ -6,7 +6,7 @@ var common = require('../common/index')
 /**
  * @typedef AvailableNumbersRequester
  * @type {Object}
- * @property {function} getList - Retrieve the list of available phone numbers for purchase.
+ * @property {function} getList - Retrieve a list of available phone numbers for purchase.
  */
 
 /**
@@ -26,7 +26,7 @@ function availableNumbers (accountId, authToken) {
   var rootUrl = '/AvailablePhoneNumbers'
 
   /**
-   * Retrieve the list of available phone numbers for purchase.
+   * Retrieve a list of available phone numbers for purchase.
    * @param {object} [filters] - An object containing a number of possible ways to filter the available phone numbers returned by Persephony.
    * @returns {Promise<object>} phone number list - The list of phone numbers available for purchase.
    * @throws will throw an error on a failed response

--- a/src/api/phoneNumbers/callingNumbers.js
+++ b/src/api/phoneNumbers/callingNumbers.js
@@ -20,7 +20,7 @@ var common = require('../common/index')
  *
  * @param {string} accountId - The accountId for authentication.
  * @param {string} authToken - The authToken for authentication.
- * @returns {CallingNumbersRequester} requester - returns a CallingNumbersRequester
+ * @returns {CallingNumbersRequester} requester - A CallingNumbersRequester
  */
 function callingNumbers (accountId, authToken) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/phoneNumbers/callingNumbers.js
+++ b/src/api/phoneNumbers/callingNumbers.js
@@ -56,7 +56,7 @@ function callingNumbers (accountId, authToken) {
 
   /**
    * Retrieve a list of calling numbers associated with the {@code accountId}.
-   * @param {object} [options] - An optional object containing a number of possible ways to filter the calling numbers returned by Persephony.
+   * @param {object} [options] - An Object containing a number of possible ways to filter the calling numbers returned by Persephony.
    * @returns {Promise<object>} calling number list - A list of calling numbers
    * @throws will throw an error on a failed response
    */
@@ -80,7 +80,7 @@ function callingNumbers (accountId, authToken) {
    * Create a new CallingNumber through the Persephony API.
    *
    * @param {string} phoneNumber - The phone number to add. Should be formatted with a '+' and country code e.g. +16175551212 (E.164 format). Persephony will also accept unformatted US numbers e.g. (415) 555-1212, 415-555-1212.
-   * @param {object} [options] - The optional properties to set on the new calling number.
+   * @param {object} [options] - The Properties to set on the new calling number.
    * @returns {Promise<object>} calling number - The newly created calling number
    * @throws will throw an error on a failed response
    */

--- a/src/api/phoneNumbers/incomingNumbers.js
+++ b/src/api/phoneNumbers/incomingNumbers.js
@@ -59,7 +59,7 @@ function incomingNumbers (accountId, authToken) {
 
   /**
    * Retrieve a list of IncomingPhoneNumbers associated with the {@code accountId}.
-   * @param {object} [filter] - An optional object containing a number of possible ways to filter the incoming numbers list returned by Persephony.
+   * @param {object} [filter] - An Object containing a number of possible ways to filter the incoming numbers list returned by Persephony.
    * @returns {Promise<object>} incoming number list - A list of Incoming Phone Numbers.
    * @throws will throw an error on a failed response
    */
@@ -83,7 +83,7 @@ function incomingNumbers (accountId, authToken) {
    * Purchase a new incoming phone number through the Persephony API.
    *
    * @param {string} phoneNumber - The phone number to purchase in E.164 format (as returned in the list of Available Phone Numbers)
-   * @param {object} [options] - Optional properties to set on the newly purchased number.
+   * @param {object} [options] - Properties to set on the newly purchased number.
    * @returns {Promise<object>} incoming number - The newly purchased incoming phone number.
    * @throws will throw an error on a failed response
    */

--- a/src/api/queues/members/members.js
+++ b/src/api/queues/members/members.js
@@ -20,7 +20,7 @@ var common = require('../../common/index')
  * @param {string} accountId - The accountId for authentication.
  * @param {string} authToken - The authToken for authentication.
  * @param {string} queueId - The queueId to operate against.
- * @returns {MembersRequester} requester - returns a MembersRequester
+ * @returns {MembersRequester} requester - A MembersRequester
  */
 function members (accountId, authToken, queueId) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/queues/queues.js
+++ b/src/api/queues/queues.js
@@ -21,7 +21,7 @@ var members = require('./members/index')
  *
  * @param {string} accountId - The accountId for authentication.
  * @param {string} authToken - The authToken for authentication.
- * @returns {QueuesRequester} requester - returns a QueuesRequester.
+ * @returns {QueuesRequester} requester - A QueuesRequester.
  */
 function queues (accountId, authToken) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/queues/queues.js
+++ b/src/api/queues/queues.js
@@ -59,7 +59,7 @@ function queues (accountId, authToken) {
   /**
    * Retrieve a list of queues associated with the {@code accountId}.
    *
-   * @param {object} [filters] - An optional object containing a number of possible ways to filter the queues returned by Persephony.
+   * @param {object} [filters] - An Object containing a number of possible ways to filter the queues returned by Persephony.
    * @returns {Promise<object>} queue list - A list of queues.
    * @throws will throw an error on a failed response
    */
@@ -82,7 +82,7 @@ function queues (accountId, authToken) {
   /**
    * Create a new queue through the Persephony API.
    *
-   * @param {object} [options] - An optional object to set the properties on the newly created queue.
+   * @param {object} [options] - An Object to set the properties on the newly created queue.
    * @returns {Promise<object>} queue - The newly created queue.
    * @throws will throw an error on a failed response
    */

--- a/src/api/recordings/recordings.js
+++ b/src/api/recordings/recordings.js
@@ -22,7 +22,7 @@ var path = require('path')
  *
  * @param {string} accountId - The accountId for authentication
  * @param {string} authToken - The authToken for authentication
- * @returns {RecordingsRequester} requester - returns a RecordingsRequester
+ * @returns {RecordingsRequester} requester - A RecordingsRequester
  */
 function recordings (accountId, authToken) {
   var getter = common.commonGetBuilder(accountId, authToken)

--- a/src/api/recordings/recordings.js
+++ b/src/api/recordings/recordings.js
@@ -47,7 +47,7 @@ function recordings (accountId, authToken) {
   /**
    * Retrieve a list of recording metadata associated with the {@code accountId}
    *
-   * @param {object} [filters] - Optional properties to filter the recording list Persephony will return
+   * @param {object} [filters] - Properties to filter the recording list Persephony will return
    * @returns {Promise<object>} recording list - A list of metadata about the available recordings
    * @throws will throw an error on a failed response
    */


### PR DESCRIPTION
- Removed the word optional on params that already have square bracket indicating they are optional
- Remove the word returns from return line of docs because it's already indicated with the return: tag
- Other minor fixes for formatting and consistency
- VCSWP-7666: Check Content & Update all GitHub SDK pages